### PR TITLE
fix: treat mmproj files as projectors, not standalone models (#2)

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -21,6 +21,9 @@ struct LocalModel {
     filename: String,
     path: String,
     size: u64,
+    /// Path to a multimodal projector (mmproj) file in the same snapshot, if
+    /// any. Passed to llama-server via `--mmproj` when the model is started.
+    mmproj: Option<String>,
 }
 
 #[derive(Clone, Serialize)]
@@ -56,6 +59,31 @@ fn hf_hub_dir() -> PathBuf {
 
 fn repo_dir(repo: &str) -> PathBuf {
     hf_hub_dir().join(format!("models--{}", repo.replace('/', "--")))
+}
+
+/// Whether a GGUF filename is a multimodal projector ("mmproj-*.gguf").
+/// These are companions to a model, not standalone models (issue #2).
+fn is_mmproj_name(name: &str) -> bool {
+    name.rsplit('/')
+        .next()
+        .unwrap_or(name)
+        .to_lowercase()
+        .contains("mmproj")
+}
+
+/// Turn a HuggingFace tree entry into a `{path, size, hash}` download descriptor.
+fn tree_file_entry(f: &serde_json::Value) -> serde_json::Value {
+    // LFS files carry the SHA256 in lfs.oid; non-LFS files use oid directly.
+    let blob_hash = f["lfs"]["oid"]
+        .as_str()
+        .or_else(|| f["oid"].as_str())
+        .unwrap_or("")
+        .to_string();
+    serde_json::json!({
+        "path": f["path"].as_str().unwrap_or(""),
+        "size": f["size"].as_u64().unwrap_or(0),
+        "hash": blob_hash,
+    })
 }
 
 // ── Connection & Server Info ─────────────────────────────────────────
@@ -373,6 +401,7 @@ async fn start_server(
     port: String,
     extra_args: String,
     model_path: Option<String>,
+    mmproj_path: Option<String>,
 ) -> Result<String, String> {
     use tauri::Emitter;
 
@@ -383,6 +412,13 @@ async fn start_server(
 
     if let Some(ref mp) = model_path {
         cmd.arg("-m").arg(mp);
+    }
+
+    // Multimodal projector for vision models (issue #2).
+    if let Some(ref mm) = mmproj_path {
+        if !mm.is_empty() {
+            cmd.arg("--mmproj").arg(mm);
+        }
     }
 
     if !extra_args.is_empty() {
@@ -517,6 +553,29 @@ async fn list_hf_files(repo: String) -> Result<serde_json::Value, String> {
         return Err("No GGUF files found in this repo".to_string());
     }
 
+    // Multimodal projector files (mmproj-*.gguf) are companions, not standalone
+    // models (issue #2). Pull them out and attach them to every model bundle so
+    // a downloaded vision model is complete. If the repo is *only* projectors,
+    // fall back to listing them so the user isn't left with nothing.
+    let is_proj = |f: &&serde_json::Value| is_mmproj_name(f["path"].as_str().unwrap_or(""));
+    let model_files: Vec<&serde_json::Value> =
+        gguf_files.iter().copied().filter(|f| !is_proj(f)).collect();
+    let mmproj_entries: Vec<serde_json::Value> = if model_files.is_empty() {
+        Vec::new()
+    } else {
+        gguf_files
+            .iter()
+            .copied()
+            .filter(is_proj)
+            .map(tree_file_entry)
+            .collect()
+    };
+    let model_files = if model_files.is_empty() {
+        gguf_files.clone()
+    } else {
+        model_files
+    };
+
     // Group split models: "foo-00001-of-00003.gguf" → base "foo"
     // Single files stay as-is
     use std::collections::BTreeMap;
@@ -525,7 +584,7 @@ async fn list_hf_files(repo: String) -> Result<serde_json::Value, String> {
 
     let mut bundles: BTreeMap<String, Vec<serde_json::Value>> = BTreeMap::new();
 
-    for f in &gguf_files {
+    for f in &model_files {
         let path = f["path"].as_str().unwrap_or("");
         let key = if let Some(caps) = split_re.captures(path) {
             // Group key is everything before the split suffix
@@ -535,18 +594,8 @@ async fn list_hf_files(repo: String) -> Result<serde_json::Value, String> {
             path.to_string()
         };
 
-        // LFS files have an lfs.oid (SHA256), non-LFS use oid directly
-        let blob_hash = f["lfs"]["oid"]
-            .as_str()
-            .or_else(|| f["oid"].as_str())
-            .unwrap_or("")
-            .to_string();
-
-        bundles.entry(key).or_default().push(serde_json::json!({
-            "path": path,
-            "size": f["size"].as_u64().unwrap_or(0),
-            "hash": blob_hash,
-        }));
+        // `f` is `&&Value` (iterating a `Vec<&Value>`); deref once for the helper.
+        bundles.entry(key).or_default().push(tree_file_entry(f));
     }
 
     // Sort files within each bundle by name
@@ -561,14 +610,19 @@ async fn list_hf_files(repo: String) -> Result<serde_json::Value, String> {
 
     let result: Vec<serde_json::Value> = bundles
         .into_iter()
-        .map(|(name, files)| {
+        .map(|(name, model_files)| {
+            // "file_count" reflects the model's own parts (for the "N parts"
+            // label); the projector files are added on top for download.
+            let file_count = model_files.len();
+            let mut files = model_files;
+            files.extend(mmproj_entries.iter().cloned());
             let total_size: u64 = files.iter().map(|f| f["size"].as_u64().unwrap_or(0)).sum();
-            let file_count = files.len();
             serde_json::json!({
                 "name": name,
                 "files": files,
                 "total_size": total_size,
                 "file_count": file_count,
+                "has_mmproj": !mmproj_entries.is_empty(),
             })
         })
         .collect();
@@ -877,10 +931,18 @@ async fn list_local_models() -> Result<Vec<LocalModel>, String> {
 
         use std::collections::BTreeMap;
         let mut bundles: BTreeMap<String, (Vec<String>, u64)> = BTreeMap::new();
+        // Multimodal projector files (mmproj-*.gguf) are companions to a model,
+        // not standalone models (issue #2). Collect them separately and attach
+        // to the models in this snapshot.
+        let mut mmproj_paths: Vec<PathBuf> = Vec::new();
 
         for file in snap_files.flatten() {
             let fname = file.file_name().to_string_lossy().to_string();
             if !fname.ends_with(".gguf") {
+                continue;
+            }
+            if is_mmproj_name(&fname) {
+                mmproj_paths.push(file.path());
                 continue;
             }
             // Follow symlink to get real file size
@@ -896,6 +958,13 @@ async fn list_local_models() -> Result<Vec<LocalModel>, String> {
             bentry.0.push(fname);
             bentry.1 += size;
         }
+
+        // Deterministically pick a projector if the snapshot has several
+        // (e.g. F16 and BF16 variants).
+        mmproj_paths.sort();
+        let mmproj = mmproj_paths
+            .first()
+            .map(|p| p.to_string_lossy().to_string());
 
         for (base_name, (mut file_list, total_size)) in bundles {
             file_list.sort();
@@ -921,6 +990,7 @@ async fn list_local_models() -> Result<Vec<LocalModel>, String> {
                 filename: file_list[0].clone(),
                 path: first_path.to_string_lossy().to_string(),
                 size: total_size,
+                mmproj: mmproj.clone(),
             });
         }
     }

--- a/ui/main.js
+++ b/ui/main.js
@@ -481,8 +481,9 @@ async function loadHfFiles(repo, quantFilter) {
     container.innerHTML = `<div class="hf-files-header muted">Select a model to download:</div>` +
       bundles.map((b, idx) => {
         const parts = b.file_count > 1 ? ` (${b.file_count} parts)` : "";
+        const vision = b.has_mmproj ? ` <span class="hf-vision-tag">+ vision projector</span>` : "";
         return `<div class="hf-file-row">
-          <span class="hf-file-name">${escapeHtml(b.name)}${parts}</span>
+          <span class="hf-file-name">${escapeHtml(b.name)}${parts}${vision}</span>
           <span class="hf-file-size muted">${formatSize(b.total_size)}</span>
           <button class="secondary-btn hf-file-dl-btn" data-idx="${idx}">Download</button>
         </div>`;
@@ -670,19 +671,23 @@ async function refreshLocalModels() {
       const runBadge = isRunning
         ? `<span class="model-status-badge loaded">PORT ${runningSrv.port}</span>`
         : "";
+      const visionBadge = m.mmproj
+        ? `<span class="model-status-badge vision" title="Multimodal — starts with --mmproj">VISION</span>`
+        : "";
       return `<div class="model-card">
         <div class="model-card-info">
           <div class="model-card-name" title="${escapeHtml(m.path)}">${escapeHtml(m.name)}</div>
           <div class="model-card-meta">${formatSize(m.size)}</div>
         </div>
+        ${visionBadge}
         ${runBadge}
-        <button class="primary-btn model-start-btn" data-path="${escapeHtml(m.path)}" data-name="${escapeHtml(m.name)}">${isRunning ? "Start Another" : "Start"}</button>
+        <button class="primary-btn model-start-btn" data-path="${escapeHtml(m.path)}" data-name="${escapeHtml(m.name)}" data-mmproj="${escapeHtml(m.mmproj || "")}">${isRunning ? "Start Another" : "Start"}</button>
         <button class="danger-btn model-delete-btn" data-path="${escapeHtml(m.path)}" data-name="${escapeHtml(m.name)}" ${isRunning ? "disabled" : ""}>Delete</button>
       </div>`;
     }).join("");
 
     container.querySelectorAll(".model-start-btn").forEach((btn) => {
-      btn.addEventListener("click", () => startLocalModel(btn.dataset.path, btn.dataset.name));
+      btn.addEventListener("click", () => startLocalModel(btn.dataset.path, btn.dataset.name, btn.dataset.mmproj));
     });
 
     container.querySelectorAll(".model-delete-btn").forEach((btn) => {
@@ -757,8 +762,8 @@ function stopServerLogListener() {
 // ── Launch Modal ──────────────────────────────────────────────────
 let pendingLaunch = null;
 
-function showLaunchModal(modelPath, modelName) {
-  pendingLaunch = { modelPath, modelName };
+function showLaunchModal(modelPath, modelName, mmproj) {
+  pendingLaunch = { modelPath, modelName, mmproj: mmproj || null };
   $("#launch-modal-model").textContent = modelName;
   $("#launch-modal").style.display = "flex";
 }
@@ -778,17 +783,17 @@ document.addEventListener("keydown", (e) => {
 
 $("#launch-modal-start").addEventListener("click", () => {
   if (!pendingLaunch) return;
-  const { modelPath, modelName } = pendingLaunch;
+  const { modelPath, modelName, mmproj } = pendingLaunch;
   closeLaunchModal();
-  doStartServer(modelPath, modelName);
+  doStartServer(modelPath, modelName, mmproj);
 });
 
 // ── Start Local Model ─────────────────────────────────────────────
-function startLocalModel(modelPath, modelName) {
-  showLaunchModal(modelPath, modelName);
+function startLocalModel(modelPath, modelName, mmproj) {
+  showLaunchModal(modelPath, modelName, mmproj);
 }
 
-async function doStartServer(modelPath, modelName) {
+async function doStartServer(modelPath, modelName, mmproj) {
   const binary = getResolvedBinary();
   if (!binary) { showBinaryModal(); return; }
 
@@ -812,7 +817,7 @@ async function doStartServer(modelPath, modelName) {
     await startServerLogListener(port);
     const extraArgs = buildServerArgs();
 
-    await invoke("start_server", { binary, port: String(port), extraArgs, modelPath });
+    await invoke("start_server", { binary, port: String(port), extraArgs, modelPath, mmprojPath: mmproj || null });
 
     runningServers.push({ port, model: modelPath, name: modelName, status: "loading" });
     renderRunningServers();

--- a/ui/style.css
+++ b/ui/style.css
@@ -804,6 +804,15 @@ input[type="checkbox"] {
 .model-status-badge.loaded { background: rgba(34,197,94,0.15); color: var(--green); }
 .model-status-badge.available { background: rgba(99,102,241,0.15); color: var(--accent); }
 .model-status-badge.loading { background: rgba(234,179,8,0.15); color: var(--yellow); }
+.model-status-badge.vision { background: rgba(168,85,247,0.15); color: #c084fc; }
+
+.hf-vision-tag {
+  font-size: 0.7rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  color: #c084fc;
+  margin-left: 0.4rem;
+}
 
 /* ── Slot Details Pane ───────────────────────────────────────────── */
 #slot-details {


### PR DESCRIPTION
## Problem

Fixes #2. Multimodal projector files (`mmproj-*.gguf`) share the `.gguf` extension, so they were listed as their own models in both the local-models list and the HuggingFace download picker.

## Fix

**Local models (`list_local_models`)**
- Projector files are no longer listed as standalone models.
- The projector path is attached to every model in the same snapshot via a new `mmproj` field (deterministically chosen if a repo ships several, e.g. F16 + BF16).
- The UI shows a `VISION` badge and threads the projector through the launch flow.

**Starting a server (`start_server`)**
- New optional `mmproj_path` argument, passed to `llama-server` as `--mmproj` so vision models load their projector.

**Downloads (`list_hf_files`)**
- Projector files are pulled out of the model bundles and appended to each model bundle's download set (flagged `has_mmproj`, shown as `+ vision projector`), so downloading a quant fetches a complete, runnable vision model.
- Repos that contain *only* projector files fall back to listing them, so nothing becomes undownloadable.

## Notes

`is_mmproj_name` / `tree_file_entry` were factored into shared helpers. Detection is name-based (`mmproj` substring), matching llama.cpp's own convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)