### PR TITLE
feat: honour llama.cpp model-source env vars (#3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@
 - **Run multiple servers simultaneously** -- each model gets its own random port, manage them all from one place
 - **Auto-detects llama-server** -- finds the binary on your PATH or common install locations
 - **Downloads to the standard HuggingFace cache** (`~/.cache/huggingface/hub/`) -- shared with `huggingface-cli`, LM Studio, and other tools
+- **Multimodal aware** -- `mmproj` projector files are recognised as companions rather than separate models and passed to llama-server via `--mmproj`
+- **Respects llama.cpp model-source env vars** -- see [Model locations](#model-locations)
 - **Open llama-server's built-in web UI** in your browser with one click
 - **Configure server options** -- context size, GPU layers, flash attention, parallel slots, and more
 - **Tune parameters** with interactive sliders and presets (Creative, Balanced, Precise, Deterministic)
@@ -38,6 +40,19 @@ Search HuggingFace for GGUF models, download them, and start serving with a few 
 - **Download progress** -- real-time progress bar with ETA, visible from any tab
 - **Popular model suggestions** -- quick-pick chips for Gemma, Qwen, Llama, Mistral, Phi, and more
 - **Multiple servers** -- run several models at once, each on its own port. Connect, open in browser, or stop individually
+
+## Model locations
+
+By default llama-panel reads and writes the standard HuggingFace hub cache at `~/.cache/huggingface/hub/`. The following environment variables (the same ones llama.cpp honours) override or extend where it looks for models:
+
+| Variable | Effect |
+| --- | --- |
+| `HF_HUB_CACHE` | Use this directory as the HuggingFace hub cache. |
+| `HF_HOME` | Use `$HF_HOME/hub` as the hub cache. |
+| `LLAMA_ARG_MODELS_DIR` | Also list loose `.gguf` files stored in this directory (llama-server's `--models` dir). |
+| `LLAMA_CACHE` | Also list loose `.gguf` files stored in this directory. |
+
+Split (multi-part) GGUFs are grouped, and `mmproj-*.gguf` projector files are attached to their model rather than listed separately.
 
 ## Server Configuration
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -91,11 +91,36 @@ fn client() -> reqwest::Client {
 }
 
 fn hf_hub_dir() -> PathBuf {
+    // Honour the standard HuggingFace cache overrides so llama-panel finds
+    // (and downloads into) the same place as the CLI tools (issue #3).
+    if let Some(dir) = std::env::var_os("HF_HUB_CACHE") {
+        return PathBuf::from(dir);
+    }
+    if let Some(home) = std::env::var_os("HF_HOME") {
+        return PathBuf::from(home).join("hub");
+    }
     let home = std::env::var("HOME").unwrap_or_else(|_| ".".to_string());
     PathBuf::from(home)
         .join(".cache")
         .join("huggingface")
         .join("hub")
+}
+
+/// Extra directories of loose GGUF files to scan, from llama.cpp's env vars
+/// (issue #3): `LLAMA_ARG_MODELS_DIR` (llama-server's `--models` dir) and
+/// `LLAMA_CACHE`. Deduplicated and only existing directories are returned.
+fn loose_model_dirs() -> Vec<PathBuf> {
+    let mut dirs: Vec<PathBuf> = Vec::new();
+    for var in ["LLAMA_ARG_MODELS_DIR", "LLAMA_CACHE"] {
+        if let Some(val) = std::env::var_os(var) {
+            let path = PathBuf::from(val);
+            let canon = std::fs::canonicalize(&path).unwrap_or_else(|_| path.clone());
+            if path.is_dir() && !dirs.contains(&canon) {
+                dirs.push(canon);
+            }
+        }
+    }
+    dirs
 }
 
 fn repo_dir(repo: &str) -> PathBuf {
@@ -929,12 +954,82 @@ async fn download_hf_model(
 
 // ── Local Model Management ──────────────────────────────────────────
 
+/// Scan a flat directory of loose GGUF files (llama-server's model dir) and
+/// append them as local models. Split parts are grouped and mmproj files are
+/// attached as projectors, mirroring the HF hub scan (issue #3).
+fn scan_loose_gguf_dir(dir: &std::path::Path, models: &mut Vec<LocalModel>) {
+    let split_re = regex::Regex::new(r"-\d{5}-of-\d{5}\.gguf$").unwrap();
+    let of_re = regex::Regex::new(r"-\d{5}-of-(\d{5})\.gguf$").unwrap();
+
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+
+    use std::collections::BTreeMap;
+    let mut bundles: BTreeMap<String, (Vec<String>, u64)> = BTreeMap::new();
+    let mut mmproj_paths: Vec<PathBuf> = Vec::new();
+
+    for file in entries.flatten() {
+        let fname = file.file_name().to_string_lossy().to_string();
+        if !fname.ends_with(".gguf") {
+            continue;
+        }
+        if is_mmproj_name(&fname) {
+            mmproj_paths.push(file.path());
+            continue;
+        }
+        let size = std::fs::metadata(file.path()).map(|m| m.len()).unwrap_or(0);
+        let key = if split_re.is_match(&fname) {
+            split_re.replace(&fname, ".gguf").to_string()
+        } else {
+            fname.clone()
+        };
+        let bentry = bundles.entry(key).or_insert_with(|| (Vec::new(), 0));
+        bentry.0.push(fname);
+        bentry.1 += size;
+    }
+
+    mmproj_paths.sort();
+    let mmproj = mmproj_paths
+        .first()
+        .map(|p| p.to_string_lossy().to_string());
+
+    for (base_name, (mut file_list, total_size)) in bundles {
+        file_list.sort();
+        // Skip incomplete split bundles.
+        if let Some(caps) = of_re.captures(&file_list[0]) {
+            let expected: usize = caps[1].parse().unwrap_or(0);
+            if file_list.len() < expected {
+                continue;
+            }
+        }
+        let first_path = dir.join(&file_list[0]);
+        let display_name = if file_list.len() > 1 {
+            format!("{base_name} ({} parts)", file_list.len())
+        } else {
+            base_name.clone()
+        };
+        models.push(LocalModel {
+            name: display_name,
+            filename: file_list[0].clone(),
+            path: first_path.to_string_lossy().to_string(),
+            size: total_size,
+            mmproj: mmproj.clone(),
+        });
+    }
+}
+
 #[tauri::command]
 async fn list_local_models() -> Result<Vec<LocalModel>, String> {
     let hub = hf_hub_dir();
     let mut models = Vec::new();
     let split_re = regex::Regex::new(r"-\d{5}-of-\d{5}\.gguf$").unwrap();
     let of_re = regex::Regex::new(r"-\d{5}-of-(\d{5})\.gguf$").unwrap();
+
+    // Loose GGUF directories configured via llama.cpp env vars (issue #3).
+    for dir in loose_model_dirs() {
+        scan_loose_gguf_dir(&dir, &mut models);
+    }
 
     if !hub.exists() {
         return Ok(models);


### PR DESCRIPTION
## Scope

Addresses part of #3. Issue #3 is a broad request (llama-server **router mode** + **llama-swap** support). This PR delivers the low-risk, self-contained foundation — honouring llama.cpp's model-source environment variables — rather than shipping an untested full router UI into a release.

_(Supersedes #7, which was auto-closed when its stacked base branch was deleted after #6 merged. Rebased onto `main`; the diff is now purely additive.)_

## Changes

- **`hf_hub_dir`** now honours `HF_HUB_CACHE` and `HF_HOME`, so the app reads from (and downloads into) the same cache as the HuggingFace CLI tools when those are configured.
- **`scan_loose_gguf_dir`** lists loose `.gguf` files from `LLAMA_ARG_MODELS_DIR` (llama-server's `--models` dir) and `LLAMA_CACHE`, with the same split-part grouping and mmproj-as-projector handling as the hub scan. Directories are deduplicated; missing ones are skipped.
- **README** gains a *Model locations* section documenting the variables.

## Not included (remaining #3 work)

- Detecting a running llama-server in **router mode** and driving it via `/models/load` + `/models/unload` from the UI (the backend commands `list_available_models` / `load_model` / `unload_model` already exist).
- `models.ini` preset management and llama-swap integration.

References #3 but does **not** close it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)